### PR TITLE
Updated document to use  goog:chromeOptions

### DIFF
--- a/docs/introduction/command-line-runner.md
+++ b/docs/introduction/command-line-runner.md
@@ -135,13 +135,13 @@ The runner will automatically set the number of workers to the same number of CP
 If you have Chrome installed in a non-standard location on your machine you can specify the path so ChromeDriver knows where to look.
 
 ```sh
-selenium-side-runner -c "chromeOptions.binary='/path/to/non-standard/Chrome/install'"
+selenium-side-runner -c "goog:chromeOptions.binary='/path/to/non-standard/Chrome/install'"
 ```
 
 With Chrome specific capabilities you can also run the tests headlessly.
 
 ```sh
-selenium-side-runner -c "chromeOptions.args=[disable-infobars, headless]"
+selenium-side-runner -c "goog:chromeOptions.args=[--disable-infobars, --headless]"
 ```
 
 ## A framework at your fingertips


### PR DESCRIPTION
 Headless flag does not work as per current documentation . Updated refer https://bugs.chromium.org/p/chromedriver/issues/detail?id=1786 & https://stackoverflow.com/questions/57128651/how-do-i-run-selenium-side-runner-headless-at-the-command-line/57181892?noredirect=1#comment100876352_57181892

<!--
Selenium IDE is moving to an electron app!!!.
For the time being the team will support both the extension and the app, until the app reaches complete feature parity with the extension.

If you want to submit a PR to the electron app, please submit to master.
To submit a PR to the extension submit to the branch v3
-->
- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)
